### PR TITLE
New update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,10 @@ and on top of that:
 - LimeSurvey configurations:
    
    - Installed from upstream source code to /var/www/limesurvey
+   - Admin area available from example.com/admin
 
 - SSL support out of the box.
-- `PHPMyAdmin`_ administration frontend for MySQL (listening on port
+- `Adminer`_ administration frontend for MySQL (listening on port
   12322 - uses SSL).
 - Postfix MTA (bound to localhost) to allow sending of email (e.g.,
   password recovery).
@@ -29,4 +30,4 @@ Credentials *(passwords set at first boot)*
 
 .. _LimeSurvey: http://www.limesurvey.org/
 .. _TurnKey Core: http://www.turnkeylinux.org/core
-.. _PHPMyAdmin: http://www.phpmyadmin.net
+.. _Adminer: http://www.adminer.org/

--- a/changelog
+++ b/changelog
@@ -1,3 +1,18 @@
+turnkey-limesurvey-14.0 (1) turnkey; urgency=low                                                                                                
+
+  * LimeSurvey:
+
+    - Upgraded to latest limesurvey release version [#69].
+
+  * Upstream source component versions:
+
+    limesurvey      206plus-build150612
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 18 Jun 2015 13:25:23 +1000
+
 turnkey-limesurvey-13.0 (1) turnkey; urgency=low
 
   * LimeSurvey:

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,10 @@ dl() {
     cd $2; curl -L -f -o limesurvey-205.tar.gz $PROXY $1; cd -
 }
 
-VERSION="205plus-build150508-tar-gz"
-URL="https://www.limesurvey.org/en/stable-release/finish/25-latest-stable-release/1248-limesurvey$VERSION"
+#VERSION="205plus-build150508-tar-gz"
+#URL="https://www.limesurvey.org/en/stable-release/finish/25-latest-stable-release/1248-limesurvey$VERSION"
+
+VERSION="limesurvey206plus-build150612.tar.gz"
+URL="http://download.limesurvey.org/latest-stable-release/$VERSION"
 
 dl $URL /usr/local/src

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,10 +5,7 @@ dl() {
     cd $2; curl -L -f -o limesurvey-205.tar.gz $PROXY $1; cd -
 }
 
-#VERSION="205plus-build150508-tar-gz"
-#URL="https://www.limesurvey.org/en/stable-release/finish/25-latest-stable-release/1248-limesurvey$VERSION"
-
-VERSION="limesurvey206plus-build150612.tar.gz"
-URL="http://download.limesurvey.org/latest-stable-release/$VERSION"
+VERSION="206plus-build150612.tar.gz"
+URL="http://download.limesurvey.org/latest-stable-release/limesurvey$VERSION"
 
 dl $URL /usr/local/src


### PR DESCRIPTION
It looks like the URL for LimeSurvey downloads has changed since this appliance was updated.

While I was fixing that I:
- updated the included version (a new version has been released since this appliance was updated).
- updated the changelog
- updated the README
- tested and confirmed that the build still works
