### PR TITLE
update to limesurvey250plus-build160731

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,10 @@
+turnkey-limesurvey-14.2 (1) turnkey; urgency=low
+
+  * Updated LimeSurvey to latest upstream stable version:
+    - limesurvey250plus-build160731
+
+ -- Ashish Kulkarni <ashish@advarisk.com>  Wed, 03 Aug 2016 16:48:51 +0530
+
 turnkey-limesurvey-14.1 (1) turnkey; urgency=low
 
   * Updated LimeSurvey to latest upstream stable version:

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -o limesurvey.tar.gz $PROXY $1; cd -
 }
 
-VERSION="250plus-build160408"
+VERSION="250plus-build160731"
 URL="http://download.limesurvey.org/latest-stable-release/limesurvey${VERSION}.tar.gz"
 
 dl $URL /usr/local/src


### PR DESCRIPTION
This fixes turnkeylinux/tracker#676 -- not sure if this can be pushed to existing versions, hence the new changelog entry targeting `14.2`.
